### PR TITLE
Add ability to work with Tabs and in other cases

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -116,13 +116,11 @@ class _ThirdPageState extends State<ThirdPage>
   void initState() {
     super.initState();
     _tabController = TabController(length: _tabCount, vsync: this);
-    WidgetsBinding.instance?.addPostFrameCallback((_) {
-      _tabController.addListener(() {
-        if (mounted) {
-          final canSwipe = _tabController.index == 0;
-          SwipeablePageSettings.of(context).canSwipe = canSwipe;
-        }
-      });
+    _tabController.addListener(() {
+      if (mounted) {
+        final canSwipe = _tabController.index == 0;
+        SwipeablePageSettings.of(context).canSwipe = canSwipe;
+      }
     });
   }
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -119,7 +119,7 @@ class _ThirdPageState extends State<ThirdPage>
     _tabController.addListener(() {
       if (mounted) {
         final canSwipe = _tabController.index == 0;
-        SwipeablePageSettings.of(context).canSwipe = canSwipe;
+        (ModalRoute.of(context) as SwipeablePageRoute).canSwipe = canSwipe;
       }
     });
   }

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -93,7 +93,8 @@ class _SecondPageState extends State<SecondPage> {
                   // swipe-gesture intercepts those gestures in the page. This way,
                   // only swipes starting from the left (LTR) or right (RTL) screen
                   // edge can be used to navigate back.
-                  canOnlySwipeFromEdge: true,
+                  canOnlySwipeFromEdge: false,
+                  canSwipe: true,
                   // You can customize the width of the detection area with
                   // `backGestureDetectionWidth`.
                   builder: (_) => ThirdPage(),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -88,13 +88,6 @@ class _SecondPageState extends State<SecondPage> {
             ElevatedButton(
               onPressed: () {
                 context.navigator.push<void>(SwipeablePageRoute(
-                  // This option has to be enabled for pages with horizontally
-                  // scrollable content, as otherwise, `SwipeablePageRoute`'s
-                  // swipe-gesture intercepts those gestures in the page. This way,
-                  // only swipes starting from the left (LTR) or right (RTL) screen
-                  // edge can be used to navigate back.
-                  canOnlySwipeFromEdge: false,
-                  canSwipe: true,
                   // You can customize the width of the detection area with
                   // `backGestureDetectionWidth`.
                   builder: (_) => ThirdPage(),
@@ -123,6 +116,14 @@ class _ThirdPageState extends State<ThirdPage>
   void initState() {
     super.initState();
     _tabController = TabController(length: _tabCount, vsync: this);
+    WidgetsBinding.instance?.addPostFrameCallback((_) {
+      _tabController.addListener(() {
+        if (mounted) {
+          final canSwipe = _tabController.index == 0;
+          SwipeablePageSettings.of(context).canSwipe = canSwipe;
+        }
+      });
+    });
   }
 
   @override

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -47,7 +47,7 @@ packages:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.7.0"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -48,6 +48,20 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.7.0"
+  nested:
+    dependency: transitive
+    description:
+      name: nested
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "1.0.0"
+  provider:
+    dependency: transitive
+    description:
+      name: provider
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "6.0.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/lib/swipeable_page_route.dart
+++ b/lib/swipeable_page_route.dart
@@ -1,4 +1,4 @@
 export 'src/app_bar/app_bar.dart' show MorphingAppBar;
 export 'src/app_bar/sliver_app_bar.dart' show MorphingSliverAppBar;
 export 'src/page_route.dart'
-    show SwipeablePageRoute, BuildContextSwipeablePageRoute;
+    show SwipeablePageRoute, BuildContextSwipeablePageRoute, SwipeablePageSettings;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,7 +13,6 @@ dependencies:
     sdk: flutter
   list_diff: ^2.0.0
   meta: ^1.3.0
-  provider: ^6.0.1
   supercharged: ^2.0.0
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -13,6 +13,7 @@ dependencies:
     sdk: flutter
   list_diff: ^2.0.0
   meta: ^1.3.0
+  provider: ^6.0.1
   supercharged: ^2.0.0
 
 dev_dependencies:


### PR DESCRIPTION
Improved gesture recognizer to intercept only used events.
Added ability to change `canSwipe` from route.
``` dart
  @override
  void initState() {
    super.initState();
    _tabController = TabController(length: _tabCount, vsync: this);
    _tabController.addListener(() {
      if (mounted) {
        final canSwipe = _tabController.index == 0;
        SwipeablePageSettings.of(context).canSwipe = canSwipe;
      }
    });
  }
```

This PR fixes https://github.com/JonasWanke/swipeable_page_route/issues/12 and https://github.com/JonasWanke/swipeable_page_route/issues/6

I found another variant to manage `canSwipe` flag and it also working.
![image](https://user-images.githubusercontent.com/4218994/138853023-63ac18ab-d8c6-4730-867e-befd33552cf5.png)
