### PR TITLE
Replace isPopGestureInProgress(route)

### DIFF
--- a/lib/src/page_route.dart
+++ b/lib/src/page_route.dart
@@ -184,7 +184,7 @@ class SwipeablePageRoute<T> extends CupertinoPageRoute<T> {
       return false;
     }
     // If we're in a gesture already, we cannot start another.
-    if (CupertinoRouteTransitionMixin.isPopGestureInProgress(route)) {
+    if (route.popGestureInProgress) {
       return false;
     }
 
@@ -264,8 +264,7 @@ class SwipeablePageRoute<T> extends CupertinoPageRoute<T> {
       context,
       animation,
       secondaryAnimation,
-      /* isSwipeGesture: */ CupertinoRouteTransitionMixin
-          .isPopGestureInProgress(route),
+      /* isSwipeGesture: */ route.popGestureInProgress,
       wrappedChild,
     );
   }


### PR DESCRIPTION
In following changes in Flutter 3.22.0, `isPopGestureInProgress(route)` is no longer available. This change uses `popGestureInProgress` instead. It seems to be backward compatible.

https://github.com/flutter/flutter/commit/2079f349621687b4fb1c8b87b6004beb7e2cdb83#diff-ab287c150de577f72439a8ad2eb308334ecdbf906ca2479f8eccb8a546c1948eL167

https://github.com/flutter/flutter/commit/2079f349621687b4fb1c8b87b6004beb7e2cdb83#diff-748ff41c8eac8d1b2daddbdc16ae69880172e1790662d957824518e1c1c4e47aR1587